### PR TITLE
Options for save_as_geotiff and field map changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ commands:
           command: |
             sudo apt update
             sudo apt upgrade
-            sudo apt install -y gdal-bin libgdal-dev
-            export CPLUS_INCLUDE_PATH=/usr/include/gdal
-            export C_INCLUDE_PATH=/usr/include/gdal
             if [ ! -d $HOME/venv ]; then
                 python3 -m venv $HOME/venv
             fi
@@ -36,24 +33,22 @@ commands:
             pip install --upgrade wheel
             pip install --upgrade setuptools
             pip install Cython
-            pip install 'numpy<1.20'
-            pip install 'pygdal==2.4.0.6'
-            pip install 'gdal==2.4.0'
-            pip install 'scipy==1.6.1'
-            pip install 'fiona==1.8.18'
-            pip install 'shapely==1.7.1'
+            pip install 'scipy==1.7.3'
+            pip install 'fiona==1.8.20'
+            pip install 'shapely==1.8.0'
             pip install girder-client
             export MAX_BUILD_CORES=2
-            if [ << parameters.ytdev >> == 1 ]; then
-                if [ ! -f $YT_DIR/README.md ]; then
-                    git clone --branch=$YT_BRANCH https://github.com/ruithnadsteud/yt $YT_DIR
-                fi
-                pushd $YT_DIR
-                git pull origin $YT_BRANCH
-                git checkout $YT_BRANCH
-                pip install -e .
-                popd
-            fi
+            pip install yt
+            # if [ << parameters.ytdev >> == 1 ]; then
+            #     if [ ! -f $YT_DIR/README.md ]; then
+            #         git clone --branch=$YT_BRANCH https://github.com/ruithnadsteud/yt $YT_DIR
+            #     fi
+            #     pushd $YT_DIR
+            #     git pull origin $YT_BRANCH
+            #     git checkout $YT_BRANCH
+            #     pip install -e .
+            #     popd
+            # fi
             # configure yt
             yt config set --global yt test_data_dir $TEST_DATA
             pip install -e .[dev]
@@ -183,7 +178,7 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.8 tests"
-           tag: "3.8.7"
+           tag: "3.8.12"
            coverage: 1
            ytdev: 1
 
@@ -198,5 +193,5 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.8 tests"
-           tag: "3.8.7"
+           tag: "3.8.12"
            ytdev: 1

--- a/tests/test_circle.py
+++ b/tests/test_circle.py
@@ -12,7 +12,7 @@ from yt_georaster.testing import requires_file
 test_data_dir = ytcfg.get("yt", "test_data_dir")
 landuse = "200km_2p5m_N38E34/200km_2p5m_N38E34.TIF"
 landsat = "Landsat-8_sample_L2/LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"
-s2 = "M2_Sentinel-2_test_data/T36MVE_20210315T075701_B01.jp2"
+s2 = "M2_Sentinel-2_test_data/S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"
 
 landsat_fns = glob.glob(os.path.join(test_data_dir, os.path.dirname(landsat), "*.TIF"))
 s2_fns = glob.glob(os.path.join(test_data_dir, os.path.dirname(s2), "*.jp2"))
@@ -55,7 +55,7 @@ def test_circle_ls():
     n2 = circle[("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1")].size
     assert_almost_equal(n1 / n2, 1, decimal=5)
 
-    n3 = circle[("T36MVE_20210315T075701", "S2_B01")].size
+    n3 = circle[("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B01")].size
     assert_almost_equal(n1 / n3, 1, decimal=5)
 
     assert_equal(n2, n3)
@@ -80,7 +80,7 @@ def test_circle_s2():
     # lower decimal precision since this sphere is smaller
     assert_almost_equal(n1 / n2, 1, decimal=3)
 
-    n3 = circle[("T36MVE_20210315T075701", "S2_B01")].size
+    n3 = circle[("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B01")].size
     assert_almost_equal(n1 / n3, 1, decimal=3)
 
     assert_equal(n2, n3)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -10,7 +10,7 @@ from yt_georaster.testing import requires_file
 
 test_data_dir = ytcfg.get("yt", "test_data_dir")
 landsat = "Landsat-8_sample_L2/LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"
-s2 = "M2_Sentinel-2_test_data/T36MVE_20210315T075701_B01.jp2"
+s2 = "M2_Sentinel-2_test_data/S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"
 
 landsat_fns = glob.glob(os.path.join(test_data_dir, os.path.dirname(landsat), "*.TIF"))
 s2_fns = glob.glob(os.path.join(test_data_dir, os.path.dirname(s2), "*.jp2"))
@@ -23,6 +23,6 @@ def test_grid():
     ds = yt.load(*fns)
 
     n1 = ds.data[("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1")].shape
-    n2 = ds.data[("T36MVE_20210315T075701", "S2_B01")].shape
+    n2 = ds.data[("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B01")].shape
     assert_equal(n1, n2)
     assert_equal(n1, tuple(ds.data.ActiveDimensions))

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -14,7 +14,7 @@ poly_multi = "example_multi-feature_polygon/multi_feature_polygon.shp"
 
 
 class GeoRasterPlotTest(TempDirTest):
-    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(S2_dir, "S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"))
     @requires_file(
         os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF")
     )
@@ -27,8 +27,8 @@ class GeoRasterPlotTest(TempDirTest):
 
         fields = [
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1_30m"),
-            ("T36MVE_20210315T075701", "S2_B06_20m"),
-            ("T36MVE_20210315T075701", "NDWI"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B06_20m"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "NDWI"),
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature"),
         ]
 
@@ -36,7 +36,7 @@ class GeoRasterPlotTest(TempDirTest):
             p = ds.plot(field)
             p.save()
 
-    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(S2_dir, "S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"))
     @requires_file(
         os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF")
     )
@@ -49,8 +49,8 @@ class GeoRasterPlotTest(TempDirTest):
 
         fields = [
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1_30m"),
-            ("T36MVE_20210315T075701", "S2_B06_20m"),
-            ("T36MVE_20210315T075701", "NDWI"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B06_20m"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "NDWI"),
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature"),
         ]
 
@@ -60,7 +60,7 @@ class GeoRasterPlotTest(TempDirTest):
             p.save()
 
     @requires_file(poly_multi)
-    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(S2_dir, "S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"))
     @requires_file(
         os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF")
     )

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -10,7 +10,7 @@ from yt_georaster.testing import requires_file
 
 test_data_dir = ytcfg.get("yt", "test_data_dir")
 landsat = "Landsat-8_sample_L2/LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"
-s2 = "M2_Sentinel-2_test_data/T36MVE_20210315T075701_B01.jp2"
+s2 = "M2_Sentinel-2_test_data/S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"
 poly_multi = "example_multi-feature_polygon/multi_feature_polygon.shp"
 poly_single = "example_polygon_mabira_forest/mabira_forest.shp"
 
@@ -29,7 +29,7 @@ def test_polygon_single():
     assert_equal(
         polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 368007
     )
-    assert_equal(polygon["T36MVE_20210315T075701", "S2_B10"].size, 368007)
+    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 368007)
 
 
 @requires_file(landsat)
@@ -43,4 +43,4 @@ def test_polygon_multi():
     assert_equal(
         polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 551624
     )
-    assert_equal(polygon["T36MVE_20210315T075701", "S2_B10"].size, 551624)
+    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 551624)

--- a/tests/test_rectangle.py
+++ b/tests/test_rectangle.py
@@ -10,7 +10,7 @@ from yt_georaster.testing import requires_file
 
 test_data_dir = ytcfg.get("yt", "test_data_dir")
 landsat = "Landsat-8_sample_L2/LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF"
-s2 = "M2_Sentinel-2_test_data/T36MVE_20210315T075701_B01.jp2"
+s2 = "M2_Sentinel-2_test_data/S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"
 
 landsat_fns = glob.glob(os.path.join(test_data_dir, os.path.dirname(landsat), "*.TIF"))
 s2_fns = glob.glob(os.path.join(test_data_dir, os.path.dirname(s2), "*.jp2"))
@@ -40,7 +40,7 @@ def test_rectangle_ls():
     n2 = rectangle[("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1")].size
     assert_almost_equal(n1 / n2, 1, decimal=3)
 
-    n3 = rectangle[("T36MVE_20210315T075701", "S2_B01")].size
+    n3 = rectangle[("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B01")].size
     assert_almost_equal(n1 / n3, 1, decimal=3)
 
     assert_equal(n2, n3)
@@ -70,7 +70,7 @@ def test_rectangle_s2():
     n2 = rectangle[("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1")].size
     assert_almost_equal(n1 / n2, 1, decimal=2)
 
-    n3 = rectangle[("T36MVE_20210315T075701", "S2_B01")].size
+    n3 = rectangle[("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B01")].size
     assert_almost_equal(n1 / n3, 1, decimal=2)
 
     assert_equal(n2, n3)
@@ -98,7 +98,7 @@ def test_rectangle_overlaps_edge():
     n2 = rectangle[("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1")].size
     assert_almost_equal(n1 / n2, 1, decimal=3)
 
-    n3 = rectangle[("T36MVE_20210315T075701", "S2_B01")].size
+    n3 = rectangle[("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B01")].size
     assert_almost_equal(n1 / n3, 1, decimal=3)
 
     assert_equal(n2, n3)

--- a/tests/test_save_as_geotiff.py
+++ b/tests/test_save_as_geotiff.py
@@ -15,7 +15,7 @@ poly_multi = "example_multi-feature_polygon/multi_feature_polygon.shp"
 
 
 class GeoRasterSaveTest(TempDirTest):
-    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(S2_dir, "S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"))
     @requires_file(
         os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF")
     )
@@ -28,8 +28,8 @@ class GeoRasterSaveTest(TempDirTest):
 
         fields = [
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1"),
-            ("T36MVE_20210315T075701", "S2_B06"),
-            ("T36MVE_20210315T075701", "NDWI"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B06"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "NDWI"),
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature"),
         ]
 
@@ -45,7 +45,7 @@ class GeoRasterSaveTest(TempDirTest):
                 err_msg=f"Saved data mismatch for field {field}.",
             )
 
-    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(S2_dir, "S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"))
     @requires_file(
         os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF")
     )
@@ -59,8 +59,8 @@ class GeoRasterSaveTest(TempDirTest):
         circle = ds.circle(ds.domain_center, (10, "km"))
         fields = [
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1"),
-            ("T36MVE_20210315T075701", "S2_B06"),
-            ("T36MVE_20210315T075701", "NDWI"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B06"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "NDWI"),
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature"),
         ]
         ds_fn, fm_fn = save_as_geotiff(
@@ -78,7 +78,7 @@ class GeoRasterSaveTest(TempDirTest):
             )
 
     @requires_file(poly_multi)
-    @requires_file(os.path.join(S2_dir, "T36MVE_20210315T075701_B01.jp2"))
+    @requires_file(os.path.join(S2_dir, "S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE_20210315T092856_B01.jp2"))
     @requires_file(
         os.path.join(LS_dir, "LC08_L2SP_171060_20210227_20210304_02_T1_SR_B1.TIF")
     )
@@ -92,7 +92,7 @@ class GeoRasterSaveTest(TempDirTest):
         polygon = ds.polygon(os.path.join(test_data_dir, poly_multi))
         fields = [
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1"),
-            ("T36MVE_20210315T075701", "S2_B06"),
+            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B06"),
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature"),
         ]
         ds_fn, fm_fn = save_as_geotiff(

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -326,6 +326,7 @@ class GeoRasterDataset(Dataset):
                 v = f.meta[key]
                 self.parameters[key] = v
             self.parameters["res"] = f.res
+            self.parameters["profile"] = f.profile
         self.current_time = 0
 
         # overwrite crs if one is provided by user

--- a/yt_georaster/image_types.py
+++ b/yt_georaster/image_types.py
@@ -136,12 +136,23 @@ class GeoManager:
             fkey = f"{fprefix}_{resolution}"
 
         fmap = self.field_map
+
+        # get the path used as key by yaml file if available
+        try:
+            paths_in_yaml = list(fmap.keys())
+            if not(fullpath in paths_in_yaml):
+                # assumes field_map:file is 1:1
+                path_from_yaml = paths_in_yaml[0]
+            else:
+                path_from_yaml = fullpath
+        except AttributeError:
+            path_from_yaml = fullpath
+
         for i in range(1, count + 1):
             fname = fkey
             if count > 1 or fname == "band":
                 fname += f"_{i}"
-
-            entry = fmap.get(ftype, {}).get(fname)
+            entry = fmap.get(path_from_yaml, {}).get(fname)
             if entry is not None:
                 field = (entry["field_type"], entry["field_name"])
                 units = entry.get("units", "")

--- a/yt_georaster/image_types.py
+++ b/yt_georaster/image_types.py
@@ -24,7 +24,13 @@ class SatGeoImage(GeoImage):
 
         search = self._regex.search(prefix)
         if search is None:
-            return None
+            # perform alternative regex search if it exists
+            if not (self._alt_regex is None):
+                search = self._alt_regex.search(prefix)
+                if search is None:
+                    return None
+            else:
+                return None
 
         groups = search.groups()
         ftype = groups[0]
@@ -34,11 +40,28 @@ class SatGeoImage(GeoImage):
 
 
 class Sentinel2(SatGeoImage):
-    _regex = re.compile(
-        r'^[A-Za-z0-9]+_[A-Za-z0-9]+_([A-Za-z0-9]+)_[A-Za-z0-9]+_'
-        r'[A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+_'
-        r'([A-Za-z0-9]+)(?:_\\d+m)?$'
+    """
+    MMM_MSIXXX_YYYYMMDDTHHMMSS_Nxxyy_ROOO_Txxxxx_yyyymmddThhmmss_PPP
+    MMM = the mission ID(S2A/S2B)
+    MSIXXX = denotes the product level (
+        MSIL1C denotes the Level-1C product level/
+        MSIL2A denotes the Level-2A product level
     )
+    YYYYMMDDTHHMMSS = acquisition datetime
+    Nxxyy = the PDGS Processing Baseline number (e.g. N0204)
+    ROOO = Relative Orbit number (R001 - R143)
+    Txxxxx = Tile Number field
+    yyyymmddThhmmss = processing datetime
+    PPP = product type (e.g. TCI)
+    """
+    _regex = re.compile(
+        r'^([A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+_'
+        r'[A-Za-z0-9]+_[A-Za-z0-9]+)_[A-Za-z0-9]+_'
+        r'([A-Za-z0-9]+)(?:_\\d+m)?$'
+    ) # skip processing datetime
+    _alt_regex = re.compile(
+        r"([A-Za-z0-9]+_[A-Za-z0-9]+)_([A-Za-z0-9]+)(?:_\d+m)?$"
+    ) # alternative regex to use
     _suffix = "jp2"
     _field_prefix = "S2"
     _band_aliases = (
@@ -76,12 +99,13 @@ class Landsat8(SatGeoImage):
     _regex = re.compile(
         r"(^L[COTEM]08_L\w{3}_\d{6}_\d{8}_\d{8}_\d{2}_\w{2})\w+_([A-Za-z0-9]+)$"
     )
+    _alt_regex = None
     _suffix = "tif"
     _field_prefix = "L8"
     _band_aliases = (
-        ("B1", ("visible_1",)),
-        ("B2", ("visible_2",)),
-        ("B3", ("visible_3",)),
+        ("B1", ("coastal_aerosol",)),
+        ("B2", ("blue",)),
+        ("B3", ("green",)),
         ("B4", ("red",)),
         ("B5", ("nir",)),
         ("B6", ("swir_1",)),
@@ -136,11 +160,10 @@ class GeoManager:
             fkey = f"{fprefix}_{resolution}"
 
         fmap = self.field_map
-
         # get the path used as key by yaml file if available
         try:
             paths_in_yaml = list(fmap.keys())
-            if not(fullpath in paths_in_yaml):
+            if len(paths_in_yaml) > 0 and not (fullpath in paths_in_yaml):
                 # assumes field_map:file is 1:1
                 path_from_yaml = paths_in_yaml[0]
             else:

--- a/yt_georaster/utilities.py
+++ b/yt_georaster/utilities.py
@@ -13,7 +13,7 @@ from yt.utilities.logger import ytLogger
 
 
 def save_as_geotiff(ds, filename, fields=None, data_source=None,
-    dtype=None, nodata=None, crs=None):
+    dtype=None, nodata=None):
     r"""
     Export georeferenced data to a reloadable geotiff.
 
@@ -49,9 +49,6 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
     nodata : optional, int/float
         The nodata value to use when applying mask before saving and also to
         save to output geotiff metadata.
-    crs : optional, str or :class: `~rasterio.crs.CRS`
-        The coordinate reference system to output your geotiff in. If none is
-        provided the CRS of the dataset is used.
 
     Returns
     -------


### PR DESCRIPTION
I've made changes to `save_as_geotiff` to allow the specification of output `dtype` and `nodata` value through key word arguments. If no `dtype` is provided the function outputs the data in the `dtype` of the primary input raster rather than always `float64`. Similarly the `nodata` value defaults to that of the primary input raster. Previously `nodata` was always given the value None.  I also looked at allowing the specification of CRS but this appears to be a bit more complex so I have left this for the moment. Maybe something to discuss? 

I have also made changes to how the field map yaml file is handled. It should now work as intended, even if the files have been moved from their original location. The field name and type should now be consistent before and after the process of saving and then loading a dataset. I believe this resolves issue #53 .

There have been further changes to the field naming process in `image_types.py` so that we can now handle either the full or shortened sentinel 2 jp2 file names. The previous work around was more elegant however I discovered that for the full-length file names, we were using the *processing* datetime in the field type name rather than the *acquisition* datetime. This is now fixed however field type names are now different depending on the input file. I have made changes to the tests and test data file names to reflect these changes and circleci appears to be happy! 🎉 