### PR TITLE
Build wheels in CI

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,41 @@
+# Based on the example from cibuildwheel
+#  https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions
+# and yt's build wheels workflow
+#  https://github.com/yt-project/yt/blob/main/.github/workflows/wheels.yaml
+
+name: Build CI Wheels
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.0
+        env:
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
+          CIBW_SKIP: "*-musllinux_*"  # these fail due to side effects from previous builds
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_ARCHS_MACOS: "x86_64"
+          CIBW_ARCHS_WINDOWS: "auto"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./wheelhouse/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+
+# Based on https://cibuildwheel.readthedocs.io/en/stable/options/#examples_9
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "Cython",
+    "numpy==1.13.3; python_version<'3.5'",
+    "oldest-supported-numpy; python_version>='3.5'",
+    "yt>=4.0.1",
+]


### PR DESCRIPTION
We've found ourselves needing to install this package in a minimal container environment with no access to build tools like Cython or gcc, where the usual `pip install -e ...` isn't an option. So I've built pre-compiled binary wheels.

I figured others might have a similar use case, so if you're interested in building wheels too, this PR has the CI setup I used to build the wheels.

I based this off upstream yt's setup for building wheels: https://github.com/yt-project/yt/blob/main/.github/workflows/wheels.yaml
but simplified to remove the upstream/yt-specific stuff, and updated to use PyPa's recommended pre-built action: https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions

The result is using PyPa's [cibuildwheel](https://github.com/pypa/cibuildwheel) package and their integration with Github Actions (every open source repo/user has 2000 free Actions minutes per month).

Currently it's configured to build Python 3.7 through to 3.10, on Win32/64, Linux and macOS, but note that so far I've only tested the Linux wheels, and I don't have access to a Mac to test the macOS wheels.

The resulting wheels are pretty small, less than 1M each! Here's the output from today: https://github.com/R2ZER0/yt_georaster/actions/runs/1553724929

I'd be happy to make changes, e.g. if you'd prefer to use CircleCI as you already do (but note that apparantly CircleCI can't build Windows wheels: https://cibuildwheel.readthedocs.io/en/stable/#usage), or if you'd like to build wheels for extra branches, or only certain tags etc.