### PR TITLE
remove step during selection of clipping window extent to primary raster bounds

### DIFF
--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -220,8 +220,8 @@ class GeoRasterGrid(YTGrid):
         left_edge = np.floor((left_edge - dle) / dds) * dds + dle
         right_edge = np.ceil((right_edge - dle) / dds) * dds + dle
 
-        left_edge.clip(min=dle, max=dre, out=left_edge)
-        right_edge.clip(min=dle, max=dre, out=right_edge)
+        # left_edge.clip(min=dle, max=dre, out=left_edge)
+        # right_edge.clip(min=dle, max=dre, out=right_edge)
         return left_edge, right_edge
 
     def _get_rasterio_window(self, selector, dst_crs, transform):


### PR DESCRIPTION
The step of clipping selections by the extent of the primary raster was suggested by me originally as a way to avoid returning arrays filled with nodata values when a selection is poorly defined through human error. Unfortunately this really limits the power of what yt/yt_georaster can do when it comes to creating mosaics of images from different scenes.

I have commented out the two lines of code which performed the clipping for now as we may want to re-introduce this as an option.

Now, the window selection is not limited to the domain of the dataset and will fill the selection outside the bounds of the dataset with zeros.