### PR TITLE
Alternative reproject method, better consistency for window selection + additional features at load

### DIFF
--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -27,9 +27,9 @@ def test_polygon_single():
 
     polygon = ds.polygon(os.path.join(test_data_dir, poly_single))
     assert_equal(
-        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 368002
+        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 368007
     )
-    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 368002)
+    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 368007)
 
 
 @requires_file(landsat)
@@ -41,6 +41,6 @@ def test_polygon_multi():
 
     polygon = ds.polygon(os.path.join(test_data_dir, poly_multi))
     assert_equal(
-        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 551609
+        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 551624
     )
-    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 551609)
+    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 551624)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -27,9 +27,9 @@ def test_polygon_single():
 
     polygon = ds.polygon(os.path.join(test_data_dir, poly_single))
     assert_equal(
-        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 368007
+        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 368002
     )
-    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 368007)
+    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 368002)
 
 
 @requires_file(landsat)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -41,6 +41,6 @@ def test_polygon_multi():
 
     polygon = ds.polygon(os.path.join(test_data_dir, poly_multi))
     assert_equal(
-        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 551624
+        polygon["LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B10"].size, 551609
     )
-    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 551624)
+    assert_equal(polygon["S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B10"].size, 551609)

--- a/tests/test_save_as_geotiff.py
+++ b/tests/test_save_as_geotiff.py
@@ -27,8 +27,6 @@ class GeoRasterSaveTest(TempDirTest):
         ds = yt.load(*fns)
 
         fields = [
-            ("LC08_L2SP_171060_20210227_20210304_02_T1", "L8_B1"),
-            ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "S2_B06"),
             ("S2A_MSIL1C_20210315T075701_N0209_R035_T36MVE", "NDWI"),
             ("LC08_L2SP_171060_20210227_20210304_02_T1", "LS_temperature"),
         ]

--- a/yt_georaster/__init__.py
+++ b/yt_georaster/__init__.py
@@ -1,5 +1,5 @@
 from yt_georaster.data_structures import GeoRasterDataset
 from yt_georaster.io import IOHandlerGeoRaster
-from yt_georaster.utilities import save_as_geotiff
+from yt_georaster.utilities import save_as_geotiff, get_field_as_raster_array
 
 __version__ = "1.0.dev0"

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -339,11 +339,11 @@ class GeoRasterDataset(Dataset):
     refine_by = 2
     _con_attrs = ()
 
-    def __init__(self, *args, field_map=None, crs=None, nodata=None):
+    def __init__(self, *args, field_map=None, nodata=None):
         self.filename_list = args
         filename = args[0]
         self.field_map = field_map
-        self.crs = crs
+        # self.crs = crs
         self.nodata = nodata
         super().__init__(filename, self._dataset_type, unit_system="mks")
         self.data = self.index.grids[0]
@@ -377,52 +377,45 @@ class GeoRasterDataset(Dataset):
         self.current_time = 0
 
         # overwrite crs if one is provided by user
-        if not (self.crs is None):
-            # make sure user provided CRS is valid CRS object
-            if not isinstance(self.crs, CRS):
-                if isinstance(self.crs, int):
-                    # assume epsg number
-                    self.crs = CRS.from_epsg(self.crs)
-                elif isinstance(self.crs, dict):
-                    self.crs = CRS.from_dict(**self.crs)
-                else:
-                    self.crs = CRS.from_string(self.crs)
+#         if not (self.crs is None):
+#             # make sure user provided CRS is valid CRS object
+#             if not isinstance(self.crs, CRS):
+#                 if isinstance(self.crs, int):
+#                     # assume epsg number
+#                     self.crs = CRS.from_epsg(self.crs)
+#                 elif isinstance(self.crs, dict):
+#                     self.crs = CRS.from_dict(**self.crs)
+#                 else:
+#                     self.crs = CRS.from_string(self.crs)
 
-            # get reprojected transform
-            left_edge = self.parameters["transform"] * (0, 0)
-            right_edge = self.parameters["transform"] * (
-                self.parameters["width"],
-                self.parameters["height"]
-            )
-            transform, width, height = warp.calculate_default_transform(
-                self.parameters["crs"],
-                self.crs,
-                self.parameters["width"],
-                self.parameters["height"],
-                left=left_edge[0],
-                bottom=left_edge[1],
-                right=right_edge[0],
-                top=right_edge[1],
-                # resolution=self.parameters["transform"][0]
-                dst_width=self.parameters["width"],
-                dst_height=self.parameters["height"]
-            )  # current solution can create rectangular pixels
-            # xs, ys = warp.transform(
-            #     self.parameters["crs"],
-            #     dst_crs,
-            #     [left_edge[0], right_edge[0]],
-            #     [left_edge[1], right_edge[1]],
-            #     zs=None
-            # )
-            # update parameters
-            self.parameters["res"] = (transform[0], -transform[4])
-            self.parameters["crs"] = self.crs
-            self.parameters["transform"] = transform
-            self.parameters["width"] = width
-            self.parameters["height"] = height
-        else:
-            # if no crs has be provided replace None with base image CRS
-            self.crs = self.parameters["crs"]
+#             # get reprojected transform
+#             left_edge = self.parameters["transform"] * (0, 0)
+#             right_edge = self.parameters["transform"] * (
+#                 self.parameters["width"],
+#                 self.parameters["height"]
+#             )
+#             transform, width, height = warp.calculate_default_transform(
+#                 self.parameters["crs"],
+#                 self.crs,
+#                 self.parameters["width"],
+#                 self.parameters["height"],
+#                 left=left_edge[0],
+#                 bottom=left_edge[1],
+#                 right=right_edge[0],
+#                 top=right_edge[1]
+#                 # resolution=self.parameters["transform"][0]
+#                 # dst_width=self.parameters["width"],
+#                 # dst_height=self.parameters["height"]
+#             )  # current solution can create rectangular pixels
+#             # update parameters
+#             self.parameters["res"] = (transform[0], -transform[4])
+#             self.parameters["crs"] = self.crs
+#             self.parameters["transform"] = transform
+#             self.parameters["width"] = width
+#             self.parameters["height"] = height
+#         else:
+#             # if no crs has be provided replace None with base image CRS
+        self.crs = self.parameters["crs"]
 
         # get units and conversion factor to metres
         self.parameters["units"] = self.parameters["crs"].linear_units

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -91,6 +91,30 @@ class GeoRasterWindowGrid(YTGrid):
         )
 
         return window
+    
+    def _get_rasterio_window_transform(self, selector, width, height, crs):
+        """
+        Calculate default transform, width, and height for a rasterio window read.
+        """
+
+        left_edge = self.LeftEdge
+        right_edge = self.RightEdge
+        
+        # width = rasterio_window.width
+        # height = rasterio_window.height
+    
+        out_transform, out_width, out_height =  warp.calculate_default_transform(
+                crs,
+                self.ds.parameters["crs"],
+                width,
+                height,
+                left=left_edge[0],
+                bottom=left_edge[1],
+                right=right_edge[0],
+                top=right_edge[1]
+            )
+        
+        return out_transform, out_width, out_height
 
 
 class GeoRasterGrid(YTGrid):
@@ -243,6 +267,29 @@ class GeoRasterGrid(YTGrid):
         )
 
         return window
+    
+    def _get_rasterio_window_transform(self, selector, width, height, crs):
+        """
+        Calculate default transform, width, and height for a rasterio window read.
+        """
+        
+        left_edge, right_edge = self._get_selection_window(selector)
+        
+        # width = rasterio_window.width
+        # height = rasterio_window.height
+    
+        out_transform, out_width, out_height =  warp.calculate_default_transform(
+                crs,
+                self.ds.parameters["crs"],
+                width,
+                height,
+                left=left_edge[0],
+                bottom=left_edge[1],
+                right=right_edge[0],
+                top=right_edge[1]
+            )
+        
+        return out_transform, out_width, out_height
 
     def __repr__(self):
         ad = self.ActiveDimensions

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -620,6 +620,14 @@ class GeoRasterDataset(Dataset):
         super()._setup_classes()
         self.polygon = functools.partial(YTPolygon, ds=weakref.proxy(self))
 
+    def polygons(self, filenames, **kwargs):
+        if kwargs:
+            pfunc = functools.partial(YTPolygon, ds=weakref.proxy(self), **kwargs)
+        else:
+            pfunc = functools.partial(YTPolygon, ds=weakref.proxy(self))
+        map_results = map(pfunc, filenames)
+        return tuple(map_results)
+
     def _set_code_unit_attributes(self):
         attrs = (
             "length_unit",

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -99,9 +99,6 @@ class GeoRasterWindowGrid(YTGrid):
 
         left_edge = self.LeftEdge
         right_edge = self.RightEdge
-        
-        # width = rasterio_window.width
-        # height = rasterio_window.height
     
         out_transform, out_width, out_height =  warp.calculate_default_transform(
                 crs,

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -92,15 +92,15 @@ class GeoRasterWindowGrid(YTGrid):
         window = from_bounds(
             *new_bounds, transform
         )
-        print(window.flatten())
+
+        # left and right edges are already rounded to enclosing pixels
+        # only need to round to nearest whole pixel
         col_off, row_off, wwidth, wheight = window.flatten()
-        wwidth = round(col_off + wwidth) - round(col_off)
-        wheight = round(row_off + wheight) - round(row_off)
-        col_off = round(col_off)
-        row_off = round(row_off)
-        print(col_off, row_off, wwidth, wheight)
-        window = Window(col_off, row_off, wwidth, wheight)
-        print(window.flatten())
+        rnd_col_off = round(col_off)
+        rnd_row_off = round(row_off)
+        wwidth = round(col_off + wwidth) - rnd_col_off
+        wheight = round(row_off + wheight) - rnd_row_off
+        window = Window(rnd_col_off, rnd_row_off, wwidth, wheight)
 
         return window
 
@@ -274,15 +274,15 @@ class GeoRasterGrid(YTGrid):
         window = from_bounds(
             *new_bounds, image_transform
         )
-        print(window.flatten())
+
+        # left and right edges are already rounded to enclosing pixels
+        # only need to round to nearest whole pixel
         col_off, row_off, wwidth, wheight = window.flatten()
-        wwidth = round(col_off + wwidth) - round(col_off)
-        wheight = round(row_off + wheight) - round(row_off)
-        col_off = round(col_off)
-        row_off = round(row_off)
-        print(col_off, row_off, wwidth, wheight)
-        window = Window(col_off, row_off, wwidth, wheight)
-        print(window.flatten())
+        rnd_col_off = round(col_off)
+        rnd_row_off = round(row_off)
+        wwidth = round(col_off + wwidth) - rnd_col_off
+        wheight = round(row_off + wheight) - rnd_row_off
+        window = Window(rnd_col_off, rnd_row_off, wwidth, wheight)
 
         return window
     

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -339,11 +339,12 @@ class GeoRasterDataset(Dataset):
     refine_by = 2
     _con_attrs = ()
 
-    def __init__(self, *args, field_map=None, crs=None):
+    def __init__(self, *args, field_map=None, crs=None, nodata=None):
         self.filename_list = args
         filename = args[0]
         self.field_map = field_map
         self.crs = crs
+        self.nodata = nodata
         super().__init__(filename, self._dataset_type, unit_system="mks")
         self.data = self.index.grids[0]
         self._added_fields = []
@@ -437,6 +438,17 @@ class GeoRasterDataset(Dataset):
                 f"Dataset CRS {self.parameters['crs']} "
                 f"units are '{self.parameters['units']}'. "
             )
+
+        # set nodata value
+        if not self.nodata is None:
+            if not self.parameters['nodata'] is None:
+                mylog.warning(
+                    f"Overwriting nodata value {self.parameters['nodata']}"
+                    f" with user defined value {self.nodata}."
+                )
+            self.parameters['nodata'] = self.nodata
+            self.parameters['profile']['nodata'] = self.nodata
+
         # set domain
         width = self.parameters["width"]
         height = self.parameters["height"]

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -3,7 +3,7 @@ import numpy as np
 import rasterio
 from rasterio import warp
 from rasterio.windows import from_bounds
-from rasterio.crs import CRS
+# from rasterio.crs import CRS
 import re
 import weakref
 

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -2,7 +2,7 @@ import functools
 import numpy as np
 import rasterio
 from rasterio import warp
-from rasterio.windows import from_bounds
+from rasterio.windows import from_bounds, Window
 from rasterio.crs import CRS
 import re
 import weakref
@@ -91,7 +91,16 @@ class GeoRasterWindowGrid(YTGrid):
         )
         window = from_bounds(
             *new_bounds, transform
-        ).round_offsets().round_lengths()
+        )
+        print(window.flatten())
+        col_off, row_off, wwidth, wheight = window.flatten()
+        wwidth = round(col_off + wwidth) - round(col_off)
+        wheight = round(row_off + wheight) - round(row_off)
+        col_off = round(col_off)
+        row_off = round(row_off)
+        print(col_off, row_off, wwidth, wheight)
+        window = Window(col_off, row_off, wwidth, wheight)
+        print(window.flatten())
 
         return window
 
@@ -234,6 +243,9 @@ class GeoRasterGrid(YTGrid):
             left_edge = dle
             right_edge = dre
 
+        left_edge = np.floor((left_edge - dle)/self.dds) * self.dds + dle
+        right_edge = np.ceil((right_edge - dle)/self.dds) * self.dds + dle
+        
         return left_edge, right_edge
 
     def _get_rasterio_window(
@@ -261,7 +273,16 @@ class GeoRasterGrid(YTGrid):
 
         window = from_bounds(
             *new_bounds, image_transform
-        ).round_offsets().round_lengths()
+        )
+        print(window.flatten())
+        col_off, row_off, wwidth, wheight = window.flatten()
+        wwidth = round(col_off + wwidth) - round(col_off)
+        wheight = round(row_off + wheight) - round(row_off)
+        col_off = round(col_off)
+        row_off = round(row_off)
+        print(col_off, row_off, wwidth, wheight)
+        window = Window(col_off, row_off, wwidth, wheight)
+        print(window.flatten())
 
         return window
     

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -488,14 +488,17 @@ class GeoRasterDataset(Dataset):
         height = int(self.parameters['height'] * self.scale_factor)
         # scale in two dimensions separately
         scale = (
-                width / self.parameters['width'],
-                height / self.parameters['height']
+                self.parameters['width'] / width,
+                self.parameters['height'] / height
         )
-        mylog.info(f"Scaling dimensions: width by {scale[0]} and height by {scale[1]}.")
+        mylog.info(f"Scaling dimensions: width by {1/scale[0]} and height by {1/scale[1]}.")
         self.parameters['width'] = width
         self.parameters['height'] = height
-        self.parameters['transform'] = transform * transform.scale(scale)
-        self.parameters['res'] = self.parameters['res'] * scale
+        self.parameters['transform'] = transform * transform.scale(*scale)
+        self.parameters['res'] = (
+            self.parameters['res'][0] * scale[0],
+            self.parameters['res'][1] * scale[1]
+        )
         self.parameters['profile'].update({
             "transform": self.parameters['transform'],
             "width": width,

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -440,8 +440,8 @@ class GeoRasterDataset(Dataset):
             )
 
         # set nodata value
-        if not self.nodata is None:
-            if not self.parameters['nodata'] is None:
+        if self.nodata is not None:
+            if self.parameters['nodata'] is not None:
                 mylog.warning(
                     f"Overwriting nodata value {self.parameters['nodata']}"
                     f" with user defined value {self.nodata}."

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -92,17 +92,19 @@ class GeoRasterWindowGrid(YTGrid):
 
         return window
     
-    def _get_rasterio_window_transform(self, selector, width, height, crs):
+    def _get_rasterio_window_transform(self, selector, width, height, crs, base_crs=None):
         """
         Calculate default transform, width, and height for a rasterio window read.
         """
 
         left_edge = self.LeftEdge
         right_edge = self.RightEdge
+        if base_crs is None:
+            base_crs = self.ds.parameters["crs"]
     
         out_transform, out_width, out_height =  warp.calculate_default_transform(
                 crs,
-                self.ds.parameters["crs"],
+                base_crs,
                 width,
                 height,
                 left=left_edge[0],
@@ -265,19 +267,19 @@ class GeoRasterGrid(YTGrid):
 
         return window
     
-    def _get_rasterio_window_transform(self, selector, width, height, crs):
+    def _get_rasterio_window_transform(self, selector, width, height, crs, base_crs=None):
         """
         Calculate default transform, width, and height for a rasterio window read.
         """
         
         left_edge, right_edge = self._get_selection_window(selector)
         
-        # width = rasterio_window.width
-        # height = rasterio_window.height
+        if base_crs is None:
+            base_crs = self.ds.parameters["crs"]
     
         out_transform, out_width, out_height =  warp.calculate_default_transform(
                 crs,
-                self.ds.parameters["crs"],
+                base_crs,
                 width,
                 height,
                 left=left_edge[0],

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -91,7 +91,7 @@ class GeoRasterWindowGrid(YTGrid):
         )
         window = from_bounds(
             *new_bounds, transform
-        ).round_offsets('floor').round_lengths('ceil')
+        ).round_offsets().round_lengths()
 
         return window
 
@@ -261,7 +261,7 @@ class GeoRasterGrid(YTGrid):
 
         window = from_bounds(
             *new_bounds, image_transform
-        ).round_offsets('floor').round_lengths('ceil')
+        ).round_offsets().round_lengths()
 
         return window
     

--- a/yt_georaster/data_structures.py
+++ b/yt_georaster/data_structures.py
@@ -62,11 +62,11 @@ class GeoRasterWindowGrid(YTGrid):
         # Make sure z dimension edges are the same as parent grid.
         self.LeftEdge[2] = gridobj.LeftEdge[2]
         self.RightEdge[2] = gridobj.RightEdge[2]
-        self.ActiveDimensions = (
+        self.ActiveDimensions = np.ceil((
             gridobj.ActiveDimensions
             * (self.RightEdge - self.LeftEdge)
             / (gridobj.RightEdge - gridobj.LeftEdge)
-        ).d.astype(np.int32)
+        ).d).astype(np.int32)
         # Inherit dx values from parent.
         self.dds = gridobj.dds
 

--- a/yt_georaster/image_types.py
+++ b/yt_georaster/image_types.py
@@ -2,6 +2,7 @@ import os
 import rasterio
 import re
 import yaml
+from pathlib import Path
 
 
 class GeoImage:
@@ -127,13 +128,21 @@ class GeoManager:
 
         self.load_field_map(field_map)
 
-    def load_field_map(self, fn):
-        if fn is None:
+    def load_field_map(self, fns):
+        if fns is None:
             self.field_map = {}
             return
+        elif not isinstance(fns, list):
+            fns = [fns]
 
-        with open(fn, mode="r") as f:
-            self.field_map = yaml.load(f, Loader=yaml.FullLoader)
+        self.field_map = {}
+        for fn in fns:
+            with open(fn, mode="r") as f:
+                field_map = yaml.load(f, Loader=yaml.FullLoader)
+            self.field_map = {
+                **self.field_map,
+                **field_map
+            }
 
     def add_field_type(self, ftype):
         if ftype not in self.ftypes:
@@ -163,7 +172,12 @@ class GeoManager:
         # get the path used as key by yaml file if available
         try:
             paths_in_yaml = list(fmap.keys())
-            if len(paths_in_yaml) > 0 and not (fullpath in paths_in_yaml):
+            file_label = Path(fullpath).name.split(".")[0]
+            if len(paths_in_yaml) > 0 and (fullpath in paths_in_yaml):
+                path_from_yaml = fullpath
+            elif len(paths_in_yaml) > 0 and (file_label in paths_in_yaml):
+                path_from_yaml = file_label
+            elif len(paths_in_yaml) > 0:
                 # assumes field_map:file is 1:1
                 path_from_yaml = paths_in_yaml[0]
             else:

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -1,7 +1,6 @@
 import numpy as np
 import rasterio
 from rasterio.warp import reproject, Resampling
-from scipy.ndimage import zoom
 
 from yt.frontends.ytdata.io import IOHandlerYTGridHDF5
 from yt.funcs import mylog

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -73,6 +73,7 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                     data = self._read_rasterio_data(selector, g, field)
                     for dim in range(len(data.shape), 3):
                         data = np.expand_dims(data, dim)
+
                     nd = g.select(selector, data, rv[field], ind)
                 ind += nd
 

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -107,6 +107,7 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
 
         src_height = rasterio_window.height
         src_width = rasterio_window.width
+
         src_transform, width, height = grid._get_rasterio_window_transform(
             selector, src_height, src_width, src_crs, base_crs=src_crs
         )
@@ -127,7 +128,7 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                 selector, base_height, base_width, src_crs
             )
 
-            reproj_data = np.zeros((height, width))
+            reproj_data = np.zeros((height, width), dtype=data.dtype)
             reproject(
                 data,
                 reproj_data,

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -100,15 +100,13 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
             data = src.read(
                 band, window=rasterio_window, out_dtype=self._field_dtype, boundless=True
             )
-            
-            image_resolution = src.res[0]
-            image_units = src.crs.linear_units
 
         # get target window
         base_window_transform, width, height = grid._get_rasterio_window_transform(
             selector, None
         )
-        
+
+        image_units = src_crs.linear_units
         base_units = self.ds.parameters["units"]
         dst_crs = self.ds.parameters["crs"]
         # reproject to base

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -74,61 +74,11 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                     data = self._read_rasterio_data(selector, g, field)
                     for dim in range(len(data.shape), 3):
                         data = np.expand_dims(data, dim)
-                    print(data.shape, rv[field].shape, ind)
                     nd = g.select(selector, data, rv[field], ind)
                 ind += nd
 
         return rv
 
-#     def _read_rasterio_data(self, selector, grid, field):
-#         """
-#         Perform rasterio read and do all transformations and resamples.
-#         """
-
-#         read_info = self.ds.index.geo_manager.fields[field]
-#         filename = read_info["filename"]
-#         band = read_info["band"]
-
-#         src = rasterio.open(filename, "r")
-
-#         # Round up rasterio window width and height.
-#         rasterio_window = grid._get_rasterio_window(selector, src.crs, src.transform)
-#         rasterio_window = rasterio_window.round_shape(op="ceil", pixel_precision=None)
-
-#         # Read in the band/field.
-#         data = src.read(
-#             band, window=rasterio_window, out_dtype=self._field_dtype, boundless=True
-#         )
-
-#         # Transform data to correct shape.
-#         data = data.T
-#         if self.ds._flip_axes:
-#             data = np.flip(data, axis=self.ds._flip_axes)
-
-#         # Resample to base resolution if necessary.
-#         image_resolution = src.res[0]
-#         image_units = src.crs.linear_units
-#         base_resolution = self.ds.resolution.d[0]
-#         base_units = self.ds.parameters['units']
-#         if round(image_resolution - base_resolution, 5) != 0.0:
-#             scale_factor = image_resolution / base_resolution
-#             mylog.info(
-#                 f"Resampling {field}: {image_resolution} {image_units} "
-#                 f"to {base_resolution} {base_units}."
-#             )
-#             data = zoom(data, scale_factor, order=0)
-
-#         # Now clip to the size of the window in the base resolution.
-#         base_window = grid._get_rasterio_window(
-#             selector, self.ds.parameters["crs"], self.ds.parameters["transform"]
-#         )
-#         data = data[: int(base_window.width), : int(base_window.height)]
-
-#         if self._cache_on:
-#             self._cached_fields.setdefault(grid.id, {})
-#             self._cached_fields[grid.id][field] = data
-
-#         return data
 
     def _read_rasterio_data(self, selector, grid, field):
         """

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -118,7 +118,7 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
             )
             scale_factor = image_resolution / base_resolution
             base_height = int(src_height * scale_factor)
-            base_width = int(src_height * scale_factor)
+            base_width = int(src_width * scale_factor)
             dst_transform, width, height = grid._get_rasterio_window_transform(
                 selector, base_height, base_width, src_crs
             )

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -151,6 +151,7 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
             selector, self.ds.parameters["crs"], self.ds.parameters["transform"]
         )
         data = data[: int(base_window.width), : int(base_window.height)]
+
         if self._cache_on:
             self._cached_fields.setdefault(grid.id, {})
             self._cached_fields[grid.id][field] = data

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -107,6 +107,9 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
 
         src_height = rasterio_window.height
         src_width = rasterio_window.width
+        src_transform, width, height = grid._get_rasterio_window_transform(
+            selector, src_height, src_width, src_crs, base_crs=src_crs
+        )
         # Resample to base resolution if necessary.
         base_resolution = self.ds.resolution.d[0]
         base_units = self.ds.parameters["units"]
@@ -119,9 +122,11 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
             scale_factor = image_resolution / base_resolution
             base_height = int(src_height * scale_factor)
             base_width = int(src_width * scale_factor)
+
             dst_transform, width, height = grid._get_rasterio_window_transform(
                 selector, base_height, base_width, src_crs
             )
+
             reproj_data = np.zeros((height, width))
             reproject(
                 data,
@@ -132,8 +137,8 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                 dst_crs=dst_crs,
                 resampling=Resampling.nearest
             )
+
             data = reproj_data
-            
 
         # Transform data to correct shape.
         data = data.T

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -116,10 +116,11 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                     f"Reprojecting {field}: {src_crs} "
                     f"to {dst_crs}."
                 )
-            mylog.info(
-                f"Resampling {field}: {src_window_transform[0]} {image_units} "
-                f"to {base_window_transform[0]} {base_units}."
-            )
+            if src_window_transform[0] != base_window_transform[0]:
+                mylog.info(
+                    f"Resampling {field}: {src_window_transform[0]} {image_units} "
+                    f"to {base_window_transform[0]} {base_units}."
+                )
 
             reproj_data = np.zeros((height, width), dtype=data.dtype)
             reproject(

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -100,7 +100,8 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                 band,
                 window=rasterio_window,
                 out_dtype=self._field_dtype,
-                boundless=True
+                boundless=True,
+                fill_value=self.ds.nodata
             )
 
         # get target window

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -73,7 +73,6 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                     data = self._read_rasterio_data(selector, g, field)
                     for dim in range(len(data.shape), 3):
                         data = np.expand_dims(data, dim)
-
                     nd = g.select(selector, data, rv[field], ind)
                 ind += nd
 
@@ -95,7 +94,6 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
 
             # Round up rasterio window width and height.
             rasterio_window = grid._get_rasterio_window(selector, src_crs, src_transform)
-            rasterio_window = rasterio_window.round_shape(op="ceil", pixel_precision=None)
             src_window_transform = src.window_transform(rasterio_window)
             # Read in the band/field.
             data = src.read(

--- a/yt_georaster/io.py
+++ b/yt_georaster/io.py
@@ -1,5 +1,6 @@
 import numpy as np
 import rasterio
+from rasterio.warp import reproject, Resampling
 from scipy.ndimage import zoom
 
 from yt.frontends.ytdata.io import IOHandlerYTGridHDF5
@@ -73,11 +74,61 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
                     data = self._read_rasterio_data(selector, g, field)
                     for dim in range(len(data.shape), 3):
                         data = np.expand_dims(data, dim)
-
+                    print(data.shape, rv[field].shape, ind)
                     nd = g.select(selector, data, rv[field], ind)
                 ind += nd
 
         return rv
+
+#     def _read_rasterio_data(self, selector, grid, field):
+#         """
+#         Perform rasterio read and do all transformations and resamples.
+#         """
+
+#         read_info = self.ds.index.geo_manager.fields[field]
+#         filename = read_info["filename"]
+#         band = read_info["band"]
+
+#         src = rasterio.open(filename, "r")
+
+#         # Round up rasterio window width and height.
+#         rasterio_window = grid._get_rasterio_window(selector, src.crs, src.transform)
+#         rasterio_window = rasterio_window.round_shape(op="ceil", pixel_precision=None)
+
+#         # Read in the band/field.
+#         data = src.read(
+#             band, window=rasterio_window, out_dtype=self._field_dtype, boundless=True
+#         )
+
+#         # Transform data to correct shape.
+#         data = data.T
+#         if self.ds._flip_axes:
+#             data = np.flip(data, axis=self.ds._flip_axes)
+
+#         # Resample to base resolution if necessary.
+#         image_resolution = src.res[0]
+#         image_units = src.crs.linear_units
+#         base_resolution = self.ds.resolution.d[0]
+#         base_units = self.ds.parameters['units']
+#         if round(image_resolution - base_resolution, 5) != 0.0:
+#             scale_factor = image_resolution / base_resolution
+#             mylog.info(
+#                 f"Resampling {field}: {image_resolution} {image_units} "
+#                 f"to {base_resolution} {base_units}."
+#             )
+#             data = zoom(data, scale_factor, order=0)
+
+#         # Now clip to the size of the window in the base resolution.
+#         base_window = grid._get_rasterio_window(
+#             selector, self.ds.parameters["crs"], self.ds.parameters["transform"]
+#         )
+#         data = data[: int(base_window.width), : int(base_window.height)]
+
+#         if self._cache_on:
+#             self._cached_fields.setdefault(grid.id, {})
+#             self._cached_fields[grid.id][field] = data
+
+#         return data
 
     def _read_rasterio_data(self, selector, grid, field):
         """
@@ -88,34 +139,52 @@ class IOHandlerGeoRaster(IOHandlerYTGridHDF5):
         filename = read_info["filename"]
         band = read_info["band"]
 
-        src = rasterio.open(filename, "r")
+        with rasterio.open(filename, "r") as src:
+            src_crs = src.crs
+            src_transform = src.transform
 
-        # Round up rasterio window width and height.
-        rasterio_window = grid._get_rasterio_window(selector, src.crs, src.transform)
-        rasterio_window = rasterio_window.round_shape(op="ceil", pixel_precision=None)
+            # Round up rasterio window width and height.
+            rasterio_window = grid._get_rasterio_window(selector, src_crs, src_transform)
+            rasterio_window = rasterio_window.round_shape(op="ceil", pixel_precision=None)
 
-        # Read in the band/field.
-        data = src.read(
-            band, window=rasterio_window, out_dtype=self._field_dtype, boundless=True
+            # Read in the band/field.
+            data = src.read(
+                band, window=rasterio_window, out_dtype=self._field_dtype, boundless=True
+            )
+            
+            
+            image_resolution = src.res[0]
+            image_units = src.crs.linear_units
+        src_height, src_width = data.shape
+        # Resample to base resolution if necessary.
+        base_resolution = self.ds.resolution.d[0]
+        base_units = self.ds.parameters["units"]
+        dst_transform, width, height = grid._get_rasterio_window_transform(
+            selector, src_height, src_width, src_crs
         )
+        dst_crs = self.ds.parameters["crs"]
+        if (image_resolution != base_resolution) or (dst_crs != src_crs):
+            mylog.info(
+                f"Resampling {field}: {image_resolution} {image_units} "
+                f"to {base_resolution} {base_units}."
+            )
+            reproj_data = np.zeros((height, width))
+            reproject(
+                data,
+                reproj_data,
+                src_transform=src_transform,
+                src_crs=src_crs,
+                dst_transform=dst_transform,
+                dst_crs=dst_crs,
+                resampling=Resampling.nearest
+            )
+            data = reproj_data
+            
 
         # Transform data to correct shape.
         data = data.T
         if self.ds._flip_axes:
             data = np.flip(data, axis=self.ds._flip_axes)
-
-        # Resample to base resolution if necessary.
-        image_resolution = src.res[0]
-        image_units = src.crs.linear_units
-        base_resolution = self.ds.resolution.d[0]
-        base_units = self.ds.parameters['units']
-        if image_resolution != base_resolution:
-            scale_factor = image_resolution / base_resolution
-            mylog.info(
-                f"Resampling {field}: {image_resolution} {image_units} "
-                f"to {base_resolution} {base_units}."
-            )
-            data = zoom(data, scale_factor, order=0)
 
         # Now clip to the size of the window in the base resolution.
         base_window = grid._get_rasterio_window(

--- a/yt_georaster/polygon.py
+++ b/yt_georaster/polygon.py
@@ -39,7 +39,7 @@ class YTPolygon(YTSelectionContainer3D):
 
     # What parameters are used to define a polygon?
     # For example, a sphere is center and radius.
-    _con_args = ("filename",)
+    _con_args = ("polygon",)
 
     # add more arguments, like path to a shape file or a shapely Polygon object
     def __init__(self, filename, ds=None, field_parameters=None, crs=None):

--- a/yt_georaster/polygon.py
+++ b/yt_georaster/polygon.py
@@ -78,14 +78,14 @@ class YTPolygon(YTSelectionContainer3D):
             # only one polygon
             self._number_features = 1
             self.polygon = filename
-            if not (self.src_crs is None):
+            if self.src_crs is not None:
                 self._reproject_polygon(ds.parameters['crs'])
 
         elif isinstance(filename, MultiPolygon):
             # only one polygon
             self._number_features = len(filename.geoms)
             self.polygon = unary_union(filename)
-            if not (self.src_crs is None):
+            if self.src_crs is not None:
                 self._reproject_polygon(ds.parameters['crs'])
 
         elif isinstance(filename, list):
@@ -95,7 +95,7 @@ class YTPolygon(YTSelectionContainer3D):
             m = MultiPolygon(filename)
             # join all shapely polygons to a single layer
             self.polygon = unary_union(m)
-            if not (self.src_crs is None):
+            if self.src_crs is not None:
                 self._reproject_polygon(ds.parameters['crs'])
 
         mylog.info(

--- a/yt_georaster/polygon_selector.pyx
+++ b/yt_georaster/polygon_selector.pyx
@@ -108,9 +108,7 @@ cdef class PolygonSelector(SelectorObject):
         shape_file = self.dobj.polygon
         ds = grid.ds
 
-        new_transform = ds._update_transform(
-            ds.parameters["transform"],
-            grid.LeftEdge, grid.RightEdge)
+        new_transform, _, _ = grid._get_rasterio_window_transform(self, None)
 
         dims = np.flip(grid.ActiveDimensions[:2])
         if self.dobj._number_features > 1:

--- a/yt_georaster/utilities.py
+++ b/yt_georaster/utilities.py
@@ -202,19 +202,19 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
     mask = data_source.selector.fill_mask(wgrid)[..., 0]
 
     field_info = {}
+    transform, _width, _height = wgrid._get_rasterio_window_transform(
+        data_source.selector, width, height, ds.parameters['crs']
+    )
+
+    if (_width != width) or (_height != height):
+        ytLogger.warning(
+            f"Error in generating transform: unexpected width/height"
+            f"difference. Width {width} -> {_width}, "
+            f"Height {height} -> {_height}"
+        )
 
     # raster profile used depends on whether we need to reproject
     if crs is None:
-        transform, _width, _height = wgrid._get_rasterio_window_transform(
-            data_source.selector, width, height, ds.parameters['crs']
-        )
-
-        if (_width != width) or (_height != height):
-            ytLogger.warning(
-                f"Error in generating transform: unexpected width/height"
-                f"difference. Width {width} -> {_width}, "
-                f"Height {height} -> {_height}"
-            )
         dst_profile = ds.parameters['profile'].copy()
         dst_profile.update(
             driver="GTiff",

--- a/yt_georaster/utilities.py
+++ b/yt_georaster/utilities.py
@@ -178,7 +178,7 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
         nodata = ds.parameters['profile']['nodata']
         if nodata is None:
             ytLogger.warning(
-                f"No nodata value set, limited masking will occur."
+                "No nodata value set, limited masking will occur."
             )
 
     if fields is None:

--- a/yt_georaster/utilities.py
+++ b/yt_georaster/utilities.py
@@ -231,6 +231,7 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
             transform=transform
         )
     else:
+        crs = ds._parse_crs(crs)
         # need to update the profile if we are to reproject
         src_profile = ds.parameters['profile'].copy()
         src_profile.update(
@@ -277,6 +278,10 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
                 # no reprojection is needed, save array to raster
                 dst.write(data, band)
             else:
+                ytLogger.info(
+                    f"Reprojecting {field}: {src_profile['crs']} "
+                    f"to {crs}."
+                )
                 # save reprojected array to raster
                 reproject(
                     source=data,

--- a/yt_georaster/utilities.py
+++ b/yt_georaster/utilities.py
@@ -176,6 +176,10 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
         save_fmap = False
     if nodata is None:
         nodata = ds.parameters['profile']['nodata']
+        if nodata is None:
+            ytLogger.warning(
+                f"No nodata value set, limited masking will occur."
+            )
 
     if fields is None:
         fields = ds.field_list
@@ -241,7 +245,7 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
         )
 
         transform, width, height = wgrid._get_rasterio_window_transform(
-            data_source.selector, width, height, crs
+            data_source.selector, width, height, ds.parameters['crs'], base_crs=crs
         )
         dst_profile = src_profile.copy()
         dst_profile.update({
@@ -275,7 +279,7 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
                     destination=rasterio.band(dst, band),
                     src_transform=src_profile['transform'],
                     src_crs=src_profile['crs'],
-                    dst_transform=transform,
+                    dst_transform=dst_profile['transform'],
                     dst_crs=crs,
                     resampling=resampling
                 )

--- a/yt_georaster/utilities.py
+++ b/yt_georaster/utilities.py
@@ -6,7 +6,7 @@ Utility functions for yt_georaster.
 """
 import numpy as np
 import rasterio
-from rasterio.warp import calculate_default_transform, reproject, Resampling
+from rasterio.warp import reproject, Resampling
 from unyt import unyt_array, unyt_quantity, uconcatenate
 import yaml
 
@@ -49,7 +49,7 @@ def get_field_as_raster_array(ds, data_source, field, nodata=None):
         data_source.selector, width, height, ds.parameters['crs']
     )
     if (_width != width) or (_height != height):
-        yt.Logger.warning(
+        ytLogger.warning(
             f"Error in generating transform: unexpected width/height"
             f"difference. Width {width} -> {_width}, "
             f"Height {height} -> {_height}"
@@ -210,7 +210,7 @@ def save_as_geotiff(ds, filename, fields=None, data_source=None,
         )
 
         if (_width != width) or (_height != height):
-            yt.Logger.warning(
+            ytLogger.warning(
                 f"Error in generating transform: unexpected width/height"
                 f"difference. Width {width} -> {_width}, "
                 f"Height {height} -> {_height}"


### PR DESCRIPTION
changes summarized:
- fixed: resampling and reprojection to different CRS now with rasterio `reproject` function
- fixed: more precise window selection and dimension definition to avoid rounding errors which occurred occasionally
- fixed: io window read can handle different projections and transforms and this is consistent with `save_as_geotiff`
- added: up/down-scaling by scalar factor at load
- added: nodata value can be defined at load to use internally (sometimes useful when geotiff's metadata doesn't have a consistent nodata value)
- added: select your rasterio resampling method at load (not always nearest neighbour anymore)
- fixed: coordinate reference system to work in can be defined at load
- added: `polygons` allows you to map a list of polygons/shapefiles to create a list of yt polygon selections
- enhanced: field_map now works for multiple files
- added: `get_field_as_raster_array` function outputs window in 2d grid as callable